### PR TITLE
Cleanup of tests

### DIFF
--- a/test/httpTests.hs
+++ b/test/httpTests.hs
@@ -6,6 +6,7 @@ import System.Posix.Unistd (sleep)
 
 import qualified Network.Shed.Httpd as Httpd
 
+import Network.Browser
 import Network.HTTP
 import Network.Stream (Result)
 import Network.URI (uriPath)
@@ -13,6 +14,7 @@ import Network.URI (uriPath)
 import Test.Framework (defaultMain, testGroup)
 import Test.Framework.Providers.HUnit
 import Test.HUnit
+
 
 basicGetRequest :: Assertion
 basicGetRequest = do
@@ -22,10 +24,25 @@ basicGetRequest = do
   body <- getResponseBody response
   assertEqual "Receiving expected response" "It works." body
 
+
+-- A vanilla HTTP request using Browser shouln't send a cookie header
+browserNoCookie :: Assertion
+browserNoCookie = do
+  (_, response) <- browse $ do
+    setOutHandler (const $ return ())
+    request $ getRequest (testUrl "/browser/no-cookie")
+  let code = rspCode response
+  assertEqual "HTTP status code" (2, 0, 0) code
+
+
 processRequest :: Httpd.Request -> IO Httpd.Response
 processRequest req = do
   case (Httpd.reqMethod req, Network.URI.uriPath (Httpd.reqURI req)) of 
     ("GET", "/basic/get") -> return $ Httpd.Response 200 [] "It works."
+    ("GET", "/browser/no-cookie") ->
+      case lookup "Cookie" (Httpd.reqHeaders req) of
+        Nothing -> return $ Httpd.Response 200 [] ""
+        Just s  -> return $ Httpd.Response 500 [] s
     _                     -> return $ Httpd.Response 500 [] "Unknown request"
 
 getResponseCode :: Result (Response a) -> IO ResponseCode
@@ -35,6 +52,9 @@ getResponseCode (Right r)  = return (rspCode r)
 tests =
   [ testGroup "Basic tests"
     [ testCase "Basic GET request" basicGetRequest
+    ]
+  , testGroup "Browser tests"
+    [ testCase "No cookie header" browserNoCookie
     ]
   ]
 


### PR DESCRIPTION
I've cleaned up the `test/httpTest.hs` file a bit and removed most of the warnings.

The server is now started using `forkIO` instead of `forkProces`, because the process kept hanging on my machine if something went wrong and it wasn't properly killed.

Added a simple test case for `Network.Browser` to check if a vanilla request doesn't send any Cookie header (in preparation for future tests based around cookies).
