### PR TITLE
Use CPP to define a separate Applicative instance if using mtl 1.

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -58,6 +58,10 @@ Flag old-base
   description: Old, monolithic base
   default: False
 
+Flag mtl1
+  description: Use the old mtl version 1.
+  default: False
+
 Library
   Exposed-modules: 
                  Network.BufferType,
@@ -80,12 +84,17 @@ Library
                  Network.HTTP.MD5Aux,
                  Network.HTTP.Utils
   GHC-options: -fwarn-missing-signatures -Wall
-  Build-depends: base >= 2 && < 4.5, network, parsec, mtl
+  Build-depends: base >= 2 && < 4.5, network, parsec
   Extensions: FlexibleInstances
   if flag(old-base)
     Build-depends: base < 3
   else
     Build-depends: base >= 3, array, old-time, bytestring
+  if flag(mtl1)
+    Build-depends: mtl >= 1.1 && < 1.2
+    CPP-Options: -DMTL1
+  else
+    Build-depends: mtl >= 2.0 && < 2.1
 
   if os(windows)
     Build-depends: Win32


### PR DESCRIPTION
Since pull request #13 (commit ddd5472) broke mtl 1 support because it doesn't have an Applicative instance for StateT, this commit uses CPP to conditionally define a different Applicative instance. It doesn't use newtype deriving, but defines Applicative in terms of Monad (but only for mtl1).

I've had to put the multiline comment on a single line since CPP choked on it.
