### PR TITLE
Document the lack of HTTPS support.

### DIFF
--- a/Network/HTTP.hs
+++ b/Network/HTTP.hs
@@ -38,6 +38,7 @@
 -- export the same functions, but leaves construction and any normalization of 
 -- @Request@s to the user.
 --
+-- /NOTE:/ This package only supports HTTP; it does not support HTTPS.
 -----------------------------------------------------------------------------
 module Network.HTTP 
        ( module Network.HTTP.Base

--- a/README
+++ b/README
@@ -10,6 +10,8 @@ of the use of @ByteString@s (lazy and strict) was inspired in part by
 Jonas Aadahl et al's experimental work on @ByteString@'ifying the HTTP 
 package a couple of years ago.
 
+This only supports HTTP; it does not support HTTPS.
+
 REQUIREMENTS
 
 * A Haskell implementation such as GHC (http://www.haskell.org/ghc/)


### PR DESCRIPTION
Just spent some time trying to figure out why this was not working with the API library I was building, only to discover a lack of HTTPS support. This pull request documents this fact.
