### PR TITLE
empty connnection pool in case connection has become invalid

### DIFF
--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -809,7 +809,9 @@ request' nullVal rqState rq = do
    case e_rsp of
     Left v 
      | (reqRetries rqState < fromMaybe defaultMaxErrorRetries mbMx) && 
-       (v == ErrorReset || v == ErrorClosed) ->
+       (v == ErrorReset || v == ErrorClosed) -> do
+       --empty connnection pool in case connection has become invalid
+       modify (\b -> b { bsConnectionPool=[] })       
        request' nullVal rqState{reqRetries=succ (reqRetries rqState)} rq
      | otherwise -> 
        return (Left v)


### PR DESCRIPTION
I've had a problem, when I downloaded a lot of files from the site site, with a ErrorClosed being reported. The connection was reporting it was closed, but I think it was still being used from the connection pool. Emptying the pool on error fixed the problem. Maybe we could only remove the same connection...
