### PR TITLE
Use `MIN_VERSION_network()` instead of CABAL-flag

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -85,22 +85,18 @@ Library
                  Network.HTTP.Utils
                  Paths_HTTP
   GHC-options: -fwarn-missing-signatures -Wall
-  Build-depends: base >= 2 && < 4.7, parsec
+  Build-depends: base >= 2 && < 4.7, network < 2.5, parsec
   Extensions: FlexibleInstances
   if flag(old-base)
     Build-depends: base < 3
   else
     Build-depends: base >= 3, array, old-time, bytestring
+
   if flag(mtl1)
     Build-depends: mtl >= 1.1 && < 1.2
     CPP-Options: -DMTL1
   else
     Build-depends: mtl >= 2.0 && < 2.2
-  if flag(network23)
-    Build-depends: network < 2.4
-    CPP-Options: -DNETWORK23
-  else
-    Build-depends: network >= 2.4 && < 2.5
 
   if flag(warn-as-error)
     ghc-options:      -Werror
@@ -116,6 +112,7 @@ Test-Suite test
   hs-source-dirs: test
   main-is: httpTests.hs
 
+  -- note: version constraints are inherited from HTTP library stanza
   build-depends:     HTTP,
                      HUnit,
                      httpd-shed,
@@ -129,7 +126,7 @@ Test-Suite test
                      warp >= 1.2 && < 1.3,
                      pureMD5 >= 2.1 && < 2.2,
                      base >= 2 && < 4.6,
-                     network < 2.5,
+                     network,
                      split >= 0.1 && < 0.2,
                      test-framework,
                      test-framework-hunit

--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -1035,10 +1035,10 @@ supportedScheme u = uriScheme u == "http:"
 -- If the second argument is not sufficient context for determining
 -- a full URI then anarchy reins.
 uriDefaultTo :: URI -> URI -> URI
-#ifdef NETWORK23
-uriDefaultTo a b = maybe a id (a `relativeTo` b)
-#else
+#if MIN_VERSION_network(2,4,0)
 uriDefaultTo a b = a `relativeTo` b
+#else
+uriDefaultTo a b = maybe a id (a `relativeTo` b)
 #endif
 
 

--- a/Network/HTTP/Auth.hs
+++ b/Network/HTTP/Auth.hs
@@ -190,10 +190,10 @@ headerToChallenge baseURI (Header _ str) =
                }
 
         annotateURIs :: [Maybe URI] -> [URI]
-#ifdef NETWORK23
-        annotateURIs = (map (\u -> fromMaybe u (u `relativeTo` baseURI))) . catMaybes
-#else
+#if MIN_VERSION_network(2,4,0)
         annotateURIs = map (`relativeTo` baseURI) . catMaybes
+#else
+        annotateURIs = (map (\u -> fromMaybe u (u `relativeTo` baseURI))) . catMaybes
 #endif
 
         -- Change These:


### PR DESCRIPTION
...for providing `network-2.4` compatibility

This replaces the CABAL-flag based approach used in
7a266219284ff33d66fa5e3f67f406c2616feab5 with a `MIN_VERSION_network()`-macro
based one, making it a bit simpler for the CABAL solver.
