### PR TITLE
Update dependencies

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -107,7 +107,7 @@ Library
 Test-Suite test
   type: exitcode-stdio-1.0
 
-  build-tools: ghc >= 6.10 && < 7.8
+  build-tools: ghc >= 6.10 && < 7.10
 
   hs-source-dirs: test
   main-is: httpTests.hs
@@ -118,14 +118,14 @@ Test-Suite test
                      httpd-shed,
                      mtl >= 2.0 && < 2.2,
                      bytestring >= 0.9 && < 0.11,
-                     case-insensitive >= 0.4 && < 0.5,
+                     case-insensitive >= 0.4 && < 1.2,
                      deepseq >= 1.3 && < 1.4,
-                     http-types >= 0.6 && < 0.8,
-                     conduit >= 0.4 && < 0.6,
+                     http-types >= 0.6 && < 0.9,
+                     conduit >= 0.4 && < 1.1,
                      wai >= 1.2 && < 1.4,
                      warp >= 1.2 && < 1.4,
                      pureMD5 >= 2.1 && < 2.2,
-                     base >= 2 && < 4.7,
+                     base >= 2 && < 4.8,
                      network,
                      split >= 0.1 && < 0.3,
                      test-framework,


### PR DESCRIPTION
Allows GHC 7.8 to be used, plus some newer versions of test dependencies.
