### PR TITLE
Fix severe performance issue affecting "cabal update"

### DIFF
--- a/Network/HTTP/Base.hs
+++ b/Network/HTTP/Base.hs
@@ -868,7 +868,7 @@ hopefulTransfer bufOps readL strs
     = readL >>= 
       either (\v -> return $ Left v)
              (\more -> if (buf_isEmpty bufOps more)
-                         then return (Right ([],foldr (flip (buf_append bufOps)) (buf_empty bufOps) strs))
+                         then return (Right ([], buf_concat bufOps $ reverse strs))
                          else hopefulTransfer bufOps readL (more:strs))
 
 -- | A necessary feature of HTTP\/1.1


### PR DESCRIPTION
This patch improves `cabal update` performance by 10x(!) on my system.  Due to this issue, `cabal update` was using an extreme amount of CPU, while it should be I/O-bound.  The reverse was taking 79s, now it takes 0.01s.
