### PR TITLE
Enable FlexibleContexts for Network.Browser

### DIFF
--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE MultiParamTypeClasses, GeneralizedNewtypeDeriving, CPP, FlexibleContexts #-}
 {- |
 
 Module      :  Network.Browser


### PR DESCRIPTION
This is needed for GHC HEAD (and the future GHC 7.10)

For more details, see
    http://permalink.gmane.org/gmane.comp.lang.haskell.glasgow.user/24612
