### PR TITLE
Use network-uri package with recent network versions

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -110,7 +110,7 @@ Library
     -- GHC 6.10 and later versions of network
     Build-depends: network >= 2.2.0.1 && < 2.3
   else
-    Build-depends: network >= 2.2.0.1 && < 2.6
+    Build-depends: network >= 2.2.0.1 && < 2.7, network-uri >= 2.6.0.0 && < 2.7
 
   build-tools: ghc >= 6.10 && < 7.10
 
@@ -142,11 +142,14 @@ Test-Suite test
                      deepseq >= 1.3.0.0 && < 1.4,
                      pureMD5 >= 0.2.4 && < 2.2,
                      base >= 3.0.3.1 && < 4.8,
-                     network >= 2.2.0.1 && < 2.6,
+                     network >= 2.2.0.1 && < 2.7,
                      split >= 0.1.3 && < 0.3,
                      test-framework >= 0.2.0 && < 0.9,
                      test-framework-hunit >= 0.2.0 && <0.4
 
+  if impl(network >= 2.6.0.0)
+    build-depends:   network-uri >= 2.6.0.0 && < 2.7
+  
   if flag(warp-tests)
     CPP-Options: -DWARP_TESTS
     build-depends:


### PR DESCRIPTION
The `network` package's URI functionality has been split off (as of version 2.6.0.0) into the separate `network-uri` package, so this commit declares a dependency on `network-uri` if a recent `network` package is used.
