### PR TITLE
Remove trailing ', but' in `Network.TCP`

### DIFF
--- a/Network/TCP.hs
+++ b/Network/TCP.hs
@@ -10,8 +10,8 @@
 -- Portability :  non-portable (not tested)
 --
 -- Some utility functions for working with the Haskell @network@ package. Mostly
--- for internal use by the @Network.HTTP@ code, but 
---      
+-- for internal use by the @Network.HTTP@ code.
+--
 -----------------------------------------------------------------------------
 module Network.TCP
    ( Connection


### PR DESCRIPTION
Small typo in the documentation header for `Network.TCP`

I just removed the trailing `, but`.

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
