### PR TITLE
liftM is required for windows

### DIFF
--- a/Network/HTTP/Proxy.hs
+++ b/Network/HTTP/Proxy.hs
@@ -25,7 +25,7 @@ module Network.HTTP.Proxy
 #endif
 -}
 
-import Control.Monad ( when, mplus, join, liftM2)
+import Control.Monad ( when, mplus, join, liftM2, liftM)
 
 #if defined(WIN32)
 import Network.HTTP.Base ( catchIO )


### PR DESCRIPTION
liftM is required for Windows. The build fails otherwise

Relevant lines:
```
#if !defined(WIN32)
windowsProxyString = return Nothing
#else
windowsProxyString = liftM (>>= parseWindowsProxy) registryProxyString
```

Error obtained by building on Windows without it:
```
Network\HTTP\Proxy.hs:85:22:
    Not in scope: `liftM'
    Perhaps you meant `liftM2' (imported from Control.Monad)
cabal: Error: some packages failed to install:
HTTP-4000.2.21 failed during the building phase. The exception was:
ExitFailure 1
```
