### PR TITLE
simpleHTTP: Catch exception from failHTTPS and turn it into Result

### DIFF
--- a/Network/HTTP.hs
+++ b/Network/HTTP.hs
@@ -106,8 +106,9 @@ import Data.Maybe ( fromMaybe )
 simpleHTTP :: (HStream ty) => Request ty -> IO (Result (Response ty))
 simpleHTTP r = do
   auth <- getAuth r
-  failHTTPS (rqURI r)
-  c <- try (openStream (host auth) (fromMaybe 80 (port auth)))
+  c <- try (do
+               failHTTPS (rqURI r)
+               openStream (host auth) (fromMaybe 80 (port auth)))
   case c of
     Left err -> return . failMisc $ show (err :: IOException)
     Right c' -> simpleHTTP_ c' r

--- a/test/httpTests.hs
+++ b/test/httpTests.hs
@@ -19,7 +19,7 @@ import Network.HTTP
 import Network.HTTP.Base
 import Network.HTTP.Auth
 import Network.HTTP.Headers
-import Network.Stream (Result)
+import Network.Stream (Result, ConnError(..))
 import Network.URI (uriPath, parseURI)
 
 import System.Environment (getArgs)
@@ -66,9 +66,9 @@ basicExample = do
 
 secureGetRequest :: (?secureTestUrl :: ServerAddress) => Assertion
 secureGetRequest = do
-  response <- try $ simpleHTTP (getRequest (?secureTestUrl "/anything"))
-  assertEqual "Threw expected exception"
-              (Left (userError "https not supported"))
+  response <- simpleHTTP (getRequest (?secureTestUrl "/anything"))
+  assertEqual "Receiving expected response"
+              (Left (ErrorMisc "user error (https not supported)"))
               (fmap show response) -- fmap show because Response isn't in Eq
 
 basicPostRequest :: (?testUrl :: ServerAddress) => Assertion


### PR DESCRIPTION
failHTTPS throws Exception when trying to connect to HTTPS. Catch this and return error as Result with message from IOException instead.

Fix unit test to comply with changed behaviour.

This pull request builds on top of pull request #102 .

Fixes #77
