### PR TITLE
HaLVM support for the HTTP library

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -111,13 +111,14 @@ Library
     Build-depends: mtl >= 2.0 && < 2.3
 
   if flag(network-uri)
-    Build-depends: network-uri == 2.6.*, network == 2.6.*
+    Build-depends: network-uri == 2.6.*
+    if os(HaLVM)
+      Build-depends: network-hans == 2.6.*
+    else
+      Build-depends: network == 2.6.*
   else
-    if flag(network-uri)
-      if os(HaLVM)
-        Build-depends: network-uri == 2.6.*, network-hans >= 0.2 && < 1.0
-      else
-        Build-depends: network-uri == 2.6.*, network == 2.6.*
+    if os(HaLVM)
+      Build-depends: network-hans == 2.6.*
     else
       Build-depends: network >= 2.2.1.8 && < 2.6
 

--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -113,7 +113,15 @@ Library
   if flag(network-uri)
     Build-depends: network-uri == 2.6.*, network == 2.6.*
   else
-    Build-depends: network >= 2.2.1.8 && < 2.6
+    if flag(network-uri)
+      if os(HaLVM)
+        Build-depends: network-uri == 2.6.*, network-hans >= 0.2 && < 1.0
+      else
+        Build-depends: network-uri == 2.6.*, network == 2.6.*
+    else
+      Build-depends: network >= 2.2.1.8 && < 2.6
+
+  build-tools: ghc >= 6.10 && < 7.10
 
   if flag(warn-as-error)
     ghc-options:      -Werror

--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -151,6 +151,11 @@ import qualified System.IO
    )
 import Data.Time.Clock ( UTCTime, getCurrentTime )
 
+#include <ghcplatform.h>
+#ifdef HaLVM_TARGET_OS
+#define MIN_VERSION_network(a,b,c) 1
+#endif
+
 
 ------------------------------------------------------------------
 ----------------------- Cookie Stuff -----------------------------

--- a/Network/HTTP/Auth.hs
+++ b/Network/HTTP/Auth.hs
@@ -36,6 +36,11 @@ import Data.Char
 import Data.Maybe
 import Data.Word ( Word8 )
 
+#include <ghcplatform.h>
+#ifdef HaLVM_TARGET_OS
+#define MIN_VERSION_network(a,b,c) 1
+#endif
+
 -- | @Authority@ specifies the HTTP Authentication method to use for
 -- a given domain/realm; @Basic@ or @Digest@.
 data Authority 


### PR DESCRIPTION
These patches are all that's required to get the HaLVM and HaNS network stack to work with the HTTP library. Any way I could get them pushed into mainline?

The alternative of this method -- faking things out by replacing network with network-hans -- would be to remove the dependency between HTTP and network somehow.
