### PR TITLE
Treat empty HTTP_PROXY as non-existent (closes #66)

### DIFF
--- a/Network/HTTP/Proxy.hs
+++ b/Network/HTTP/Proxy.hs
@@ -160,6 +160,7 @@ fetchProxy warnIfIllformed = do
 -- | @parseProxy str@ translates a proxy server string into a @Proxy@ value;
 -- returns @Nothing@ if not well-formed.
 parseProxy :: String -> Maybe Proxy
+parseProxy "" = Nothing
 parseProxy str = join
                    . fmap uri2proxy
                    $ parseHttpURI str


### PR DESCRIPTION
No more cryptic error messages when `HTTP_PROXY` is empty. (resolves #66 )