### PR TITLE
Use Network.Socket.close

### DIFF
--- a/Network/StreamSocket.hs
+++ b/Network/StreamSocket.hs
@@ -29,9 +29,11 @@ import Network.Stream
    ( Stream(..), ConnError(ErrorReset, ErrorMisc), Result
    )
 import Network.Socket
-   ( Socket, getSocketOption, shutdown, send, recv, sClose
+   ( Socket, getSocketOption, shutdown, send, recv
    , ShutdownCmd(ShutdownBoth), SocketOption(SoError)
    )
+import qualified Network.Socket
+   ( close )
 
 import Network.HTTP.Base ( catchIO )
 import Control.Monad (liftM)
@@ -59,7 +61,7 @@ instance Stream Socket where
     close sk          = do
         -- This slams closed the connection (which is considered rude for TCP\/IP)
          shutdown sk ShutdownBoth
-         sClose sk
+         Network.Socket.close sk
     closeOnEnd _sk _  = return () -- can't really deal with this, so do run the risk of leaking sockets here.
 
 readBlockSocket :: Socket -> Int -> IO (Result String)

--- a/Network/TCP.hs
+++ b/Network/TCP.hs
@@ -38,11 +38,13 @@ import Network.Socket
    ( Socket, SocketOption(KeepAlive)
    , SocketType(Stream), connect
    , shutdown, ShutdownCmd(..)
-   , sClose, setSocketOption, getPeerName
+   , setSocketOption, getPeerName
    , socket, Family(AF_UNSPEC), defaultProtocol, getAddrInfo
    , defaultHints, addrFamily, withSocketsDo
    , addrSocketType, addrAddress
    )
+import qualified Network.Socket
+   ( close )
 import qualified Network.Stream as Stream
    ( Stream(readBlock, readLine, writeBlock, close, closeOnEnd) )
 import Network.Stream
@@ -242,7 +244,7 @@ openTCPConnection_ uri port stashInput = do
                             setSocketOption s KeepAlive 1
                             connect s (addrAddress a)
                             socketConnection_ fixedUri port s stashInput
-                            ) (sClose s)
+                            ) (Network.Socket.close s)
 
 -- | @socketConnection@, like @openConnection@ but using a pre-existing 'Socket'.
 socketConnection :: BufferType ty
@@ -295,7 +297,7 @@ closeConnection ref readL = do
     suck readL
     hClose (connHandle conn)
     shutdown sk ShutdownReceive
-    sClose sk
+    Network.Socket.close sk
 
   suck :: IO Bool -> IO ()
   suck rd = do


### PR DESCRIPTION
instead of deprecated sClose,
and adjust imports accordingly.