### PR TITLE
Allow building with network-3.1.0.0.

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -122,7 +122,7 @@ Library
     Build-depends: mtl >= 2.0 && < 2.3
 
   if flag(network-uri)
-    Build-depends: network-uri == 2.6.*, network >= 2.6 && < 3.1
+    Build-depends: network-uri == 2.6.*, network >= 2.6 && < 3.2
   else
     Build-depends: network >= 2.4 && < 2.6
 
@@ -157,7 +157,7 @@ Test-Suite test
                      test-framework-hunit >= 0.3.0 && <0.4
 
   if flag(network-uri)
-    Build-depends: network-uri == 2.6.*, network >= 2.6 && < 3.1
+    Build-depends: network-uri == 2.6.*, network >= 2.6 && < 3.2
   else
     Build-depends: network >= 2.3 && < 2.6
 
@@ -176,5 +176,3 @@ Test-Suite test
       build-depends:
                          conduit >= 1.1 && < 1.4,
                          conduit-extra >= 1.1 && < 1.4
-
-


### PR DESCRIPTION
Main change in 3.1.0.0 seems to be the deprecation of `fdSocket`, which is not used by `HTTP`.