### PR TITLE
base 4.13 compatibility

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -109,7 +109,7 @@ Library
 
   -- note the test harness constraints should be kept in sync with these
   -- where dependencies are shared
-  Build-depends: base >= 4.3.0.0 && < 4.13, parsec >= 2.0 && < 3.2
+  Build-depends: base >= 4.3.0.0 && < 4.14, parsec >= 2.0 && < 3.2
   Build-depends: array >= 0.3.0.2 && < 0.6, bytestring >= 0.9.1.5 && < 0.11
   Build-depends: time >= 1.1.2.3 && < 1.10
 
@@ -151,7 +151,7 @@ Test-Suite test
                      bytestring >= 0.9.1.5 && < 0.11,
                      deepseq >= 1.3.0.0 && < 1.5,
                      pureMD5 >= 0.2.4 && < 2.2,
-                     base >= 4.3.0.0 && < 4.13,
+                     base >= 4.3.0.0 && < 4.14,
                      split >= 0.1.3 && < 0.3,
                      test-framework >= 0.2.0 && < 0.9,
                      test-framework-hunit >= 0.3.0 && <0.4

--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -133,6 +133,9 @@ import Network.HTTP.Proxy
 
 import Network.Stream ( ConnError(..), Result )
 import Network.BufferType
+#if (MIN_VERSION_base(4,9,0)) && !(MIN_VERSION_base(4,13,0))
+import Control.Monad.Fail
+#endif
 
 import Data.Char (toLower)
 import Data.List (isPrefixOf)
@@ -422,7 +425,12 @@ instance Applicative (BrowserAction conn) where
   pure  = return
   (<*>) = ap
 #else
- deriving (Functor, Applicative, Monad, MonadIO, MonadState (BrowserState conn))
+ deriving
+ ( Functor, Applicative, Monad, MonadIO, MonadState (BrowserState conn)
+#if MIN_VERSION_base(4,9,0)
+ , MonadFail
+#endif
+ )
 #endif
 
 runBA :: BrowserState conn -> BrowserAction conn a -> IO a
@@ -720,7 +728,7 @@ request req = nextRequest $ do
     Left e  -> do
      let errStr = ("Network.Browser.request: Error raised " ++ show e)
      err errStr
-     fail errStr
+     Prelude.fail errStr
  where
   initialState = nullRequestState
   nullVal      = buf_empty bufferOps

--- a/Network/HTTP/Base.hs
+++ b/Network/HTTP/Base.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP, ScopedTypeVariables #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Network.HTTP.Base
@@ -209,7 +209,11 @@ uriAuthPort mbURI u =
   default_http  = 80
   default_https = 443
 
+#if MIN_VERSION_base(4,13,0)
+failHTTPS :: MonadFail m => URI -> m ()
+#else
 failHTTPS :: Monad m => URI -> m ()
+#endif
 failHTTPS uri
   | map toLower (uriScheme uri) == "https:" = fail "https not supported"
   | otherwise = return ()
@@ -713,7 +717,11 @@ urlEncodeVars [] = []
 
 -- | @getAuth req@ fishes out the authority portion of the URL in a request's @Host@
 -- header.
+#if MIN_VERSION_base(4,13,0)
+getAuth :: MonadFail m => Request ty -> m URIAuthority
+#else
 getAuth :: Monad m => Request ty -> m URIAuthority
+#endif
 getAuth r = 
    -- ToDo: verify that Network.URI functionality doesn't take care of this (now.)
   case parseURIAuthority auth of


### PR DESCRIPTION
`base` 4.13 removes `fail` from `Monad`. This patch works around that by using `MonadFail` constraints where appropriate on GHC 8.8 and supplying an instance of `MonadFail` back to 4.9 for `BrowserAction`