### PR TITLE
Replace derived Eq instance for HeaderName with manual instance (fixes #128)

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -142,6 +142,8 @@ Test-Suite test
     Httpd
     UnitTests
 
+  ghc-options: -Wall
+
   -- note: version constraints for dependencies shared with the library
   -- should be the same
   build-depends:     HTTP,

--- a/Network/HTTP/Headers.hs
+++ b/Network/HTTP/Headers.hs
@@ -130,7 +130,61 @@ data HeaderName
  | HdrContentTransferEncoding
     -- | Allows for unrecognised or experimental headers.
  | HdrCustom String -- not in header map below.
-    deriving(Eq)
+
+instance Eq HeaderName where
+    HdrCustom a                == HdrCustom b                = (toLower <$> a) == (toLower <$> b)
+    HdrCacheControl            == HdrCacheControl            = True
+    HdrConnection              == HdrConnection              = True
+    HdrDate                    == HdrDate                    = True
+    HdrPragma                  == HdrPragma                  = True
+    HdrTransferEncoding        == HdrTransferEncoding        = True
+    HdrUpgrade                 == HdrUpgrade                 = True
+    HdrVia                     == HdrVia                     = True
+    HdrAccept                  == HdrAccept                  = True
+    HdrAcceptCharset           == HdrAcceptCharset           = True
+    HdrAcceptEncoding          == HdrAcceptEncoding          = True
+    HdrAcceptLanguage          == HdrAcceptLanguage          = True
+    HdrAuthorization           == HdrAuthorization           = True
+    HdrCookie                  == HdrCookie                  = True
+    HdrExpect                  == HdrExpect                  = True
+    HdrFrom                    == HdrFrom                    = True
+    HdrHost                    == HdrHost                    = True
+    HdrIfModifiedSince         == HdrIfModifiedSince         = True
+    HdrIfMatch                 == HdrIfMatch                 = True
+    HdrIfNoneMatch             == HdrIfNoneMatch             = True
+    HdrIfRange                 == HdrIfRange                 = True
+    HdrIfUnmodifiedSince       == HdrIfUnmodifiedSince       = True
+    HdrMaxForwards             == HdrMaxForwards             = True
+    HdrProxyAuthorization      == HdrProxyAuthorization      = True
+    HdrRange                   == HdrRange                   = True
+    HdrReferer                 == HdrReferer                 = True
+    HdrUserAgent               == HdrUserAgent               = True
+    HdrAge                     == HdrAge                     = True
+    HdrLocation                == HdrLocation                = True
+    HdrProxyAuthenticate       == HdrProxyAuthenticate       = True
+    HdrPublic                  == HdrPublic                  = True
+    HdrRetryAfter              == HdrRetryAfter              = True
+    HdrServer                  == HdrServer                  = True
+    HdrSetCookie               == HdrSetCookie               = True
+    HdrTE                      == HdrTE                      = True
+    HdrTrailer                 == HdrTrailer                 = True
+    HdrVary                    == HdrVary                    = True
+    HdrWarning                 == HdrWarning                 = True
+    HdrWWWAuthenticate         == HdrWWWAuthenticate         = True
+    HdrAllow                   == HdrAllow                   = True
+    HdrContentBase             == HdrContentBase             = True
+    HdrContentEncoding         == HdrContentEncoding         = True
+    HdrContentLanguage         == HdrContentLanguage         = True
+    HdrContentLength           == HdrContentLength           = True
+    HdrContentLocation         == HdrContentLocation         = True
+    HdrContentMD5              == HdrContentMD5              = True
+    HdrContentRange            == HdrContentRange            = True
+    HdrContentType             == HdrContentType             = True
+    HdrETag                    == HdrETag                    = True
+    HdrExpires                 == HdrExpires                 = True
+    HdrLastModified            == HdrLastModified            = True
+    HdrContentTransferEncoding == HdrContentTransferEncoding = True
+    _                          == _                          = False
 
 -- | @headerMap@ is a straight assoc list for translating between header names 
 -- and values.

--- a/Network/HTTP/Headers.hs
+++ b/Network/HTTP/Headers.hs
@@ -132,59 +132,160 @@ data HeaderName
  | HdrCustom String -- not in header map below.
 
 instance Eq HeaderName where
-    HdrCustom a                == HdrCustom b                = (toLower <$> a) == (toLower <$> b)
+    HdrCustom a                == HdrCustom b                = (fmap toLower a) == (fmap toLower b)
     HdrCacheControl            == HdrCacheControl            = True
+    HdrCacheControl            == _                          = False
+    _                          == HdrCacheControl            = False
     HdrConnection              == HdrConnection              = True
+    HdrConnection              == _                          = False
+    _                          == HdrConnection              = False
     HdrDate                    == HdrDate                    = True
+    HdrDate                    == _                          = False
+    _                          == HdrDate                    = False
     HdrPragma                  == HdrPragma                  = True
+    HdrPragma                  == _                          = False
+    _                          == HdrPragma                  = False
     HdrTransferEncoding        == HdrTransferEncoding        = True
+    HdrTransferEncoding        == _                          = False
+    _                          == HdrTransferEncoding        = False
     HdrUpgrade                 == HdrUpgrade                 = True
+    HdrUpgrade                 == _                          = False
+    _                          == HdrUpgrade                 = False
     HdrVia                     == HdrVia                     = True
+    HdrVia                     == _                          = False
+    _                          == HdrVia                     = False
     HdrAccept                  == HdrAccept                  = True
+    HdrAccept                  == _                          = False
+    _                          == HdrAccept                  = False
     HdrAcceptCharset           == HdrAcceptCharset           = True
+    HdrAcceptCharset           == _                          = False
+    _                          == HdrAcceptCharset           = False
     HdrAcceptEncoding          == HdrAcceptEncoding          = True
+    HdrAcceptEncoding          == _                          = False
+    _                          == HdrAcceptEncoding          = False
     HdrAcceptLanguage          == HdrAcceptLanguage          = True
+    HdrAcceptLanguage          == _                          = False
+    _                          == HdrAcceptLanguage          = False
     HdrAuthorization           == HdrAuthorization           = True
+    HdrAuthorization           == _                          = False
+    _                          == HdrAuthorization           = False
     HdrCookie                  == HdrCookie                  = True
+    HdrCookie                  == _                          = False
+    _                          == HdrCookie                  = False
     HdrExpect                  == HdrExpect                  = True
+    HdrExpect                  == _                          = False
+    _                          == HdrExpect                  = False
     HdrFrom                    == HdrFrom                    = True
+    HdrFrom                    == _                          = False
+    _                          == HdrFrom                    = False
     HdrHost                    == HdrHost                    = True
+    HdrHost                    == _                          = False
+    _                          == HdrHost                    = False
     HdrIfModifiedSince         == HdrIfModifiedSince         = True
+    HdrIfModifiedSince         == _                          = False
+    _                          == HdrIfModifiedSince         = False
     HdrIfMatch                 == HdrIfMatch                 = True
+    HdrIfMatch                 == _                          = False
+    _                          == HdrIfMatch                 = False
     HdrIfNoneMatch             == HdrIfNoneMatch             = True
+    HdrIfNoneMatch             == _                          = False
+    _                          == HdrIfNoneMatch             = False
     HdrIfRange                 == HdrIfRange                 = True
+    HdrIfRange                 == _                          = False
+    _                          == HdrIfRange                 = False
     HdrIfUnmodifiedSince       == HdrIfUnmodifiedSince       = True
+    HdrIfUnmodifiedSince       == _                          = False
+    _                          == HdrIfUnmodifiedSince       = False
     HdrMaxForwards             == HdrMaxForwards             = True
+    HdrMaxForwards             == _                          = False
+    _                          == HdrMaxForwards             = False
     HdrProxyAuthorization      == HdrProxyAuthorization      = True
+    HdrProxyAuthorization      == _                          = False
+    _                          == HdrProxyAuthorization      = False
     HdrRange                   == HdrRange                   = True
+    HdrRange                   == _                          = False
+    _                          == HdrRange                   = False
     HdrReferer                 == HdrReferer                 = True
+    HdrReferer                 == _                          = False
+    _                          == HdrReferer                 = False
     HdrUserAgent               == HdrUserAgent               = True
+    HdrUserAgent               == _                          = False
+    _                          == HdrUserAgent               = False
     HdrAge                     == HdrAge                     = True
+    HdrAge                     == _                          = False
+    _                          == HdrAge                     = False
     HdrLocation                == HdrLocation                = True
+    HdrLocation                == _                          = False
+    _                          == HdrLocation                = False
     HdrProxyAuthenticate       == HdrProxyAuthenticate       = True
+    HdrProxyAuthenticate       == _                          = False
+    _                          == HdrProxyAuthenticate       = False
     HdrPublic                  == HdrPublic                  = True
+    HdrPublic                  == _                          = False
+    _                          == HdrPublic                  = False
     HdrRetryAfter              == HdrRetryAfter              = True
+    HdrRetryAfter              == _                          = False
+    _                          == HdrRetryAfter              = False
     HdrServer                  == HdrServer                  = True
+    HdrServer                  == _                          = False
+    _                          == HdrServer                  = False
     HdrSetCookie               == HdrSetCookie               = True
+    HdrSetCookie               == _                          = False
+    _                          == HdrSetCookie               = False
     HdrTE                      == HdrTE                      = True
+    HdrTE                      == _                          = False
+    _                          == HdrTE                      = False
     HdrTrailer                 == HdrTrailer                 = True
+    HdrTrailer                 == _                          = False
+    _                          == HdrTrailer                 = False
     HdrVary                    == HdrVary                    = True
+    HdrVary                    == _                          = False
+    _                          == HdrVary                    = False
     HdrWarning                 == HdrWarning                 = True
+    HdrWarning                 == _                          = False
+    _                          == HdrWarning                 = False
     HdrWWWAuthenticate         == HdrWWWAuthenticate         = True
+    HdrWWWAuthenticate         == _                          = False
+    _                          == HdrWWWAuthenticate         = False
     HdrAllow                   == HdrAllow                   = True
+    HdrAllow                   == _                          = False
+    _                          == HdrAllow                   = False
     HdrContentBase             == HdrContentBase             = True
+    HdrContentBase             == _                          = False
+    _                          == HdrContentBase             = False
     HdrContentEncoding         == HdrContentEncoding         = True
+    HdrContentEncoding         == _                          = False
+    _                          == HdrContentEncoding         = False
     HdrContentLanguage         == HdrContentLanguage         = True
+    HdrContentLanguage         == _                          = False
+    _                          == HdrContentLanguage         = False
     HdrContentLength           == HdrContentLength           = True
+    HdrContentLength           == _                          = False
+    _                          == HdrContentLength           = False
     HdrContentLocation         == HdrContentLocation         = True
+    HdrContentLocation         == _                          = False
+    _                          == HdrContentLocation         = False
     HdrContentMD5              == HdrContentMD5              = True
+    HdrContentMD5              == _                          = False
+    _                          == HdrContentMD5              = False
     HdrContentRange            == HdrContentRange            = True
+    HdrContentRange            == _                          = False
+    _                          == HdrContentRange            = False
     HdrContentType             == HdrContentType             = True
+    HdrContentType             == _                          = False
+    _                          == HdrContentType             = False
     HdrETag                    == HdrETag                    = True
+    HdrETag                    == _                          = False
+    _                          == HdrETag                    = False
     HdrExpires                 == HdrExpires                 = True
+    HdrExpires                 == _                          = False
+    _                          == HdrExpires                 = False
     HdrLastModified            == HdrLastModified            = True
+    HdrLastModified            == _                          = False
+    _                          == HdrLastModified            = False
     HdrContentTransferEncoding == HdrContentTransferEncoding = True
-    _                          == _                          = False
+    HdrContentTransferEncoding == _                          = False
+    _                          == HdrContentTransferEncoding = False
 
 -- | @headerMap@ is a straight assoc list for translating between header names 
 -- and values.

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -1,9 +1,11 @@
 module UnitTests ( unitTests ) where
 
 import Network.HTTP.Base
+import Network.HTTP.Headers
 import Network.URI
 
 import Data.Maybe ( fromJust )
+import Data.Either ( fromRight )
 
 import Test.Framework ( testGroup )
 import Test.Framework.Providers.HUnit
@@ -22,11 +24,47 @@ parseIPv6Address =
          (Just (URIAuthority {user = Nothing, password = Nothing, host = "::1", port = Just 5313}))
          (parseURIAuthority (uriToAuthorityString (fromJust (parseURI "http://[::1]:5313/foo"))))
 
+customHeaderNameComparison :: Assertion
+customHeaderNameComparison =
+    assertEqual "custom header name" (HdrCustom "foo") (HdrCustom "Foo")
+
+customHeaderLookup :: Assertion
+customHeaderLookup =
+    let val = "header value"
+        h = Header (HdrCustom "foo") val
+
+    in assertEqual "custom header lookup" (Just val)
+        (lookupHeader (HdrCustom "Foo") [h])
+
+caseInsensitiveHeaderParse :: Assertion
+caseInsensitiveHeaderParse =
+    let expected = [ Header HdrContentType "blah"
+                   , Header (HdrCustom "X-Unknown") "unused"
+                   ]
+        input = [ "content-type: blah"
+                , "X-Unknown: unused"
+                ]
+
+        match actual =
+            length actual == length expected &&
+            and [ hdrName a == hdrName b && hdrValue a == hdrValue b
+                | (a, b) <- zip expected actual
+                ]
+
+    in case parseHeaders input of
+        Left _ -> assertFailure "Failed header parse"
+        Right actual -> assert (match actual)
+
 unitTests =
     [testGroup "Unit tests"
         [ testGroup "URI parsing"
             [ testCase "Parse IPv4 address" parseIPv4Address
             , testCase "Parse IPv6 address" parseIPv6Address
             ]
+        ]
+    , testGroup "Header tests"
+        [ testCase "Custom header name case-insensitive match" customHeaderNameComparison
+        , testCase "Custom header lookup" customHeaderLookup
+        , testCase "Case-insensitive parsing" caseInsensitiveHeaderParse
         ]
     ]

--- a/test/UnitTests.hs
+++ b/test/UnitTests.hs
@@ -5,7 +5,6 @@ import Network.HTTP.Headers
 import Network.URI
 
 import Data.Maybe ( fromJust )
-import Data.Either ( fromRight )
 
 import Test.Framework ( testGroup )
 import Test.Framework.Providers.HUnit


### PR DESCRIPTION
This change replaces the derived Eq instance with one that causes custom headers to be compared case-insensitively. This is because situations where header name matching is done (such as via lookupHeader along with many other cases) should ignore case, but prior to this change it was possible to mismatch headers even when they had the same (case-insensitive) name.