### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -110,7 +110,7 @@ Library
   -- note the test harness constraints should be kept in sync with these
   -- where dependencies are shared
   Build-depends: base >= 4.3.0.0 && < 4.15, parsec >= 2.0 && < 3.2
-  Build-depends: array >= 0.3.0.2 && < 0.6, bytestring >= 0.9.1.5 && < 0.11
+  Build-depends: array >= 0.3.0.2 && < 0.6, bytestring >= 0.9.1.5 && < 0.12
   Build-depends: time >= 1.1.2.3 && < 1.11
 
   default-language: Haskell98
@@ -152,7 +152,7 @@ Test-Suite test
                      HUnit >= 1.2.0.1 && < 1.7,
                      httpd-shed >= 0.4 && < 0.5,
                      mtl >= 1.1.1.0 && < 2.3,
-                     bytestring >= 0.9.1.5 && < 0.11,
+                     bytestring >= 0.9.1.5 && < 0.12,
                      deepseq >= 1.3.0.0 && < 1.5,
                      pureMD5 >= 0.2.4 && < 2.2,
                      base >= 4.3.0.0 && < 4.15,


### PR DESCRIPTION
Tested with 
```cabal
packages: .
tests: true

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

source-repository-package
  type: git
  location: https://github.com/Bodigrim/pureMD5
  tag: 28b42962399adbe848e234c96ba5c76dbf071002

allow-newer:
  regex-base:bytestring,
  regex-posix:bytestring
```