### PR TITLE
Allow time-1.11

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -111,7 +111,7 @@ Library
   -- where dependencies are shared
   Build-depends: base >= 4.3.0.0 && < 4.15, parsec >= 2.0 && < 3.2
   Build-depends: array >= 0.3.0.2 && < 0.6, bytestring >= 0.9.1.5 && < 0.12
-  Build-depends: time >= 1.1.2.3 && < 1.11
+  Build-depends: time >= 1.1.2.3 && < 1.12
 
   default-language: Haskell98
   default-extensions: FlexibleInstances


### PR DESCRIPTION
The following passes:

    cabal test all --enable-tests -j --constrain 'time == 1.11.1.1'