### PR TITLE
Build with mtl-2.3-rc3 & drop flag mtl1

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -114,15 +114,17 @@ Library
   -- note the test harness constraints should be kept in sync with these
   -- where dependencies are shared
   build-depends:
-      base        >= 4.6.0.0  && < 4.17
-    , array       >= 0.3.0.2  && < 0.6
-    , bytestring  >= 0.9.1.5  && < 0.12
-    , parsec      >= 2.0      && < 3.2
-    , time        >= 1.1.2.3  && < 1.13
+      base          >= 4.6.0.0   && < 4.17
+    , array         >= 0.3.0.2   && < 0.6
+    , bytestring    >= 0.9.1.5   && < 0.12
+    , parsec        >= 2.0       && < 3.2
+    , time          >= 1.1.2.3   && < 1.13
+    , transformers  >= 0.2.0.0   && < 0.7
+        -- transformers-0.2.0.0 is the first to have Control.Monad.IO.Class
     -- The following dependencies are refined by flags, but they should
     -- still be mentioned here on the top-level.
-    , mtl         >= 1.1.1.0  && < 2.3
-    , network     >= 2.4      && < 3.2
+    , mtl           >= 1.1.1.0   && < 2.3
+    , network       >= 2.4       && < 3.2
 
   default-language: Haskell98
   default-extensions: FlexibleInstances

--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -66,10 +66,6 @@ Source-Repository head
   type: git
   location: https://github.com/haskell/HTTP.git
 
-Flag mtl1
-  description: Use the old mtl version 1.
-  default: False
-
 Flag warn-as-error
   default:     False
   description: Build with warnings-as-errors
@@ -123,17 +119,11 @@ Library
         -- transformers-0.2.0.0 is the first to have Control.Monad.IO.Class
     -- The following dependencies are refined by flags, but they should
     -- still be mentioned here on the top-level.
-    , mtl           >= 1.1.1.0   && < 2.3
+    , mtl           >= 2.0.0.0   && < 2.3
     , network       >= 2.4       && < 3.2
 
   default-language: Haskell98
   default-extensions: FlexibleInstances
-
-  if flag(mtl1)
-    Build-depends: mtl < 1.2
-    CPP-Options: -DMTL1
-  else
-    Build-depends: mtl >= 2.0
 
   if flag(network-uri)
     Build-depends: network-uri == 2.6.*, network >= 2.6

--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -143,11 +143,7 @@ import Data.Maybe (fromMaybe, listToMaybe, catMaybes )
 #if !MIN_VERSION_base(4,8,0)
 import Control.Applicative (Applicative (..), (<$>))
 #endif
-#ifdef MTL1
-import Control.Monad (filterM, forM_, when, ap)
-#else
 import Control.Monad (filterM, forM_, when)
-#endif
 import Control.Monad.IO.Class
    ( MonadIO (..) )
 import Control.Monad.State
@@ -423,20 +419,12 @@ instance Show (BrowserState t) where
 -- | @BrowserAction@ is the IO monad, but carrying along a 'BrowserState'.
 newtype BrowserAction conn a
  = BA { unBA :: StateT (BrowserState conn) IO a }
-#ifdef MTL1
- deriving (Functor, Monad, MonadIO, MonadState (BrowserState conn))
-
-instance Applicative (BrowserAction conn) where
-  pure  = return
-  (<*>) = ap
-#else
  deriving
  ( Functor, Applicative, Monad, MonadIO, MonadState (BrowserState conn)
 #if MIN_VERSION_base(4,9,0)
  , MonadFail
 #endif
  )
-#endif
 
 runBA :: BrowserState conn -> BrowserAction conn a -> IO a
 runBA bs = flip evalStateT bs . unBA

--- a/Network/Browser.hs
+++ b/Network/Browser.hs
@@ -140,13 +140,18 @@ import Control.Monad.Fail
 import Data.Char (toLower)
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe, listToMaybe, catMaybes )
+#if !MIN_VERSION_base(4,8,0)
 import Control.Applicative (Applicative (..), (<$>))
+#endif
 #ifdef MTL1
 import Control.Monad (filterM, forM_, when, ap)
 #else
 import Control.Monad (filterM, forM_, when)
 #endif
-import Control.Monad.State (StateT (..), MonadIO (..), modify, gets, withStateT, evalStateT, MonadState (..))
+import Control.Monad.IO.Class
+   ( MonadIO (..) )
+import Control.Monad.State
+   ( MonadState(..), gets, modify, StateT (..), evalStateT, withStateT )
 
 import qualified System.IO
    ( hSetBuffering, hPutStr, stdout, stdin, hGetChar


### PR DESCRIPTION
- Build also with RC3 of `mtl-2.3` which removes some reexports.  In our case, `MonadIO` is relevant.  Import it from `transformers` instead, from module `Control.Monad.IO.Class`.
- Drop flag `mtl1` and require `mtl >= 2`.  Since makes sense since we require GHC >= 7.6, which comes with mtl-2.