### PR TITLE
Allow Win32-2.14

### DIFF
--- a/HTTP.cabal
+++ b/HTTP.cabal
@@ -145,7 +145,7 @@ Library
     ghc-options:      -Werror
 
   if os(windows)
-    Build-depends: Win32 >= 2.2.0.0 && < 2.14
+    Build-depends: Win32 >= 2.2.0.0 && < 2.15
 
 Test-Suite test
   type: exitcode-stdio-1.0


### PR DESCRIPTION
Tested locally with GHC 9.12.

As a Hackage trustee I made a matching revision: https://hackage.haskell.org/package/HTTP-4000.4.1/revisions/